### PR TITLE
Modernize for Ruby 3.0+ and Rails 6.0+ (1.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
         ruby: ['3.0', '3.1', '3.2', '3.3']
         rails: ['6.0', '6.1', '7.0', '7.1', '7.2', '8.0']
         exclude:
-          # Rails 7.2+ requires Ruby 3.1+
           - ruby: '3.0'
             rails: '7.2'
           - ruby: '3.0'
@@ -31,16 +30,16 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler: '2.6'
         bundler-cache: true
 
     - name: Run tests
       run: bundle exec rake
 
-    - name: Run RuboCop
-      run: bundle exec rubocop
-
-  security:
+  lint:
     runs-on: ubuntu-latest
+    env:
+      RAILS_VERSION: '8.0'
 
     steps:
     - uses: actions/checkout@v4
@@ -49,6 +48,25 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.3'
+        bundler: '2.6'
+        bundler-cache: true
+
+    - name: Run RuboCop
+      run: bundle exec rubocop
+
+  security:
+    runs-on: ubuntu-latest
+    env:
+      RAILS_VERSION: '8.1'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler: '2.6'
         bundler-cache: true
 
     - name: Security audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.0', '3.1', '3.2', '3.3']
+        rails: ['6.0', '6.1', '7.0', '7.1', '7.2', '8.0']
+        exclude:
+          # Rails 7.2+ requires Ruby 3.1+
+          - ruby: '3.0'
+            rails: '7.2'
+          - ruby: '3.0'
+            rails: '8.0'
+
+    env:
+      RAILS_VERSION: ${{ matrix.rails }}
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
+
+    - name: Run tests
+      run: bundle exec rake
+
+    - name: Run RuboCop
+      run: bundle exec rubocop
+
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.3'
+        bundler-cache: true
+
+    - name: Security audit
+      run: bundle exec bundle-audit --update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
             rails: '7.2'
           - ruby: '3.0'
             rails: '8.0'
+          - ruby: '3.1'
+            rails: '8.0'
 
     env:
       RAILS_VERSION: ${{ matrix.rails }}
@@ -30,7 +32,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-        bundler: '2.6'
+        bundler: '2.4.22'
         bundler-cache: true
 
     - name: Run tests
@@ -48,7 +50,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.3'
-        bundler: '2.6'
+        bundler: '2.4.22'
         bundler-cache: true
 
     - name: Run RuboCop
@@ -66,7 +68,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.3'
-        bundler: '2.6'
+        bundler: '2.4.22'
         bundler-cache: true
 
     - name: Security audit

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,38 @@
+## Ruby/Bundler
 /.bundle/
-/.yardoc
+/vendor/bundle/
 /Gemfile.lock
+
+## Documentation
+/.yardoc/
 /_yardoc/
-/coverage/
 /doc/
-/pkg/
+/rdoc/
+
+## Testing
+/coverage/
 /spec/reports/
+/test/tmp/
+/test/version_tmp/
+
+## Build artifacts
+/pkg/
 /tmp/
+*.gem
+
+## IDE and OS files
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.ruby-version
+.ruby-gemset
+
+## Environment
+.env
+.env.local
+
+## Logs
+npm-debug.log

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,34 @@
+AllCops:
+  TargetRubyVersion: 3.0
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - 'vendor/**/*'
+    - 'bin/**/*'
+
+Style/Documentation:
+  Enabled: false
+
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+
+Layout/LineLength:
+  Max: 120
+  Exclude:
+    - '*.gemspec'
+
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - '*.gemspec'
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
+Gemspec/AddRuntimeDependency:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.4
-  - 2.1.5
-  - 2.2.1
-before_install: gem install bundler -v 1.10.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-05-30
+
+### ⚠️ Breaking Changes
+
+- **BREAKING**: Updated minimum Ruby version from 1.9.3 to 3.0
+  - Ruby 2.7 reached EOL in March 2023
+- **BREAKING**: Updated minimum Rails version to 6.0
+  - Now supports Rails 6.0, 6.1, 7.0, 7.1, 7.2, and 8.0
+
+### Added
+
+- Added explicit `railties` runtime dependency (>= 6.0, < 9.0)
+- Added comprehensive CHANGELOG file
+- Added detailed UPGRADE_GUIDE.md for migration assistance
+- Added GitHub Actions CI workflow (.github/workflows/ci.yml) replacing Travis CI
+- Added RuboCop configuration and linting in CI
+- Added bundler-audit security scanning in CI
+- Added RSpec test suite
+- Added gem metadata for better RubyGems.org integration:
+  - Changelog URI
+  - Bug tracker URI
+  - Documentation URI
+  - Source code URI
+  - MFA requirement
+
+### Changed
+
+- Updated development dependencies to use semantic versioning:
+  - bundler ~> 2.4
+  - rake ~> 13.0
+  - rspec ~> 3.12
+- Updated README.md with modern Rails asset pipeline instructions:
+  - Sprockets configuration
+  - Import Maps setup (Rails 7+)
+  - Webpacker/Shakapacker notes
+- Removed .travis.yml (Travis CI no longer supports free open source)
+- Improved .gitignore with additional patterns
+
+### Documentation
+
+- Comprehensive upgrade guide for migrating from 0.x to 1.0
+- Modern asset pipeline setup instructions
+- jQuery dependency documentation
+
+### Notes
+
+- All existing functionality preserved
+- Configuration files (config/protip.yml) remain unchanged
+- JavaScript API unchanged
+
+## [0.1.2] - Previous Release
+
+### Features
+
+- jQuery Protip tooltip integration for Rails
+- Configurable via protip.yml
+- Animation support via animate.css
+- Integration with Rails asset pipeline
+
+---
+
+For upgrade instructions, see [UPGRADE_GUIDE.md](UPGRADE_GUIDE.md)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,13 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, we pledge to respect all people who contribute through reporting issues, posting feature requests, updating documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free experience for everyone, regardless of level of experience, gender, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, or religion.
+
+Examples of unacceptable behavior by participants include the use of sexual language or imagery, derogatory comments or personal attacks, trolling, public or private harassment, insults, or other unprofessional conduct.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed from the project team.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening an issue or contacting one or more of the project maintainers.
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.0.0, available at [http://contributor-covenant.org/version/1/0/0/](http://contributor-covenant.org/version/1/0/0/)

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
 
-# Specify your gem's dependencies in rails-protip.gemspec
+source "https://rubygems.org"
+
 gemspec
+
+if (rails_version = ENV.fetch("RAILS_VERSION", nil))
+  gem "railties", "~> #{rails_version}.0"
+end

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # Rails::Protip
 
-[![Build Status](https://travis-ci.org/ethirajsrinivasan/rails-protip.svg?branch=master)](https://travis-ci.org/ethirajsrinivasan/rails-protip)
-[![Code Climate](https://codeclimate.com/github/ethirajsrinivasan/rails-protip/badges/gpa.svg)](https://codeclimate.com/github/ethirajsrinivasan/rails-protip)
-[![security](https://hakiri.io/github/ethirajsrinivasan/rails-protip/master.svg)](https://hakiri.io/github/ethirajsrinivasan/rails-protip/master)
+[![CI](https://github.com/ethirajsrinivasan/rails-protip/actions/workflows/ci.yml/badge.svg)](https://github.com/ethirajsrinivasan/rails-protip/actions/workflows/ci.yml)
+[![Gem Version](https://badge.fury.io/rb/rails-protip.svg)](https://badge.fury.io/rb/rails-protip)
 
+Tooltip gem based on the jQuery Protip plugin
 
-rails-protip is tooltip gem based on jquery protip plugin
+## Requirements
 
+- Ruby >= 3.0
+- Rails >= 6.0
 
 ## Installation
 
@@ -24,35 +26,90 @@ Or install it yourself as:
 
     $ gem install rails-protip
 
-To use this gem add this require statement to your application.js file:
+### Asset Pipeline Setup
 
-    //= require protip
+**For Rails 6.x / 7.x with Sprockets:**
 
-and in application.css file as follows
+Add this require statement to your `application.js` file:
 
-	*= require protip
+```javascript
+//= require protip
+```
+
+And in your `application.css` file:
+
+```css
+*= require protip
+```
+
+**For Rails 7+ with Import Maps:**
+
+Add to your `config/importmap.rb`:
+
+```ruby
+pin "protip", to: "protip.js"
+```
+
+Then import in your `application.js`:
+
+```javascript
+import "protip"
+```
+
+**For Rails with Webpacker/Shakapacker:**
+
+The gem works with the asset pipeline. If using Webpacker, you may need to configure it to load from the gem's assets directory.
+
+**Note:** This gem requires jQuery. Make sure jQuery is loaded before protip.
 
 ## Usage
 
-	<%= link_to "Go to the bar!","#bar", class: "protip", "data-pt-title"=> "You must be at least 18!"%>
+```erb
+<%= link_to "Go to the bar!", "#bar", class: "protip", "data-pt-title" => "You must be at least 18!" %>
+```
 
-You can also set default configuration in protip.yml under config folder, example
+You can also set default configuration in `protip.yml` under the config folder, example:
 
-	scheme: "orange"
-	skin: "square"
+```yaml
+scheme: "orange"
+skin: "square"
+```
 
-Support for animation is also provided, example
+Support for animation is also provided, example:
 
-	<div class="protip" data-pt-animate="infinite bounce" data-pt-title="You must be at least 18!">Go to the bar!</div>
+```html
+<div class="protip" data-pt-animate="infinite bounce" data-pt-title="You must be at least 18!">Go to the bar!</div>
+```
 
 For further usage check http://protip.rocks
 
+## Upgrading from 0.x to 1.0
+
+Version 1.0.0 introduces breaking changes to support modern Ruby and Rails versions:
+
+### Breaking Changes
+
+- **Ruby**: Minimum version increased from 1.9.3 to 3.0
+- **Rails**: Minimum version increased to 6.0
+
+### Migration Steps
+
+1. Ensure your application is running Ruby 3.0+ and Rails 6.0+
+2. Update your Gemfile: `gem 'rails-protip', '~> 1.0'`
+3. Run `bundle update rails-protip`
+4. If using Rails 7+ with Import Maps, follow the new installation instructions above
+5. Test your tooltips to ensure they still work as expected
+
+See [UPGRADE_GUIDE.md](UPGRADE_GUIDE.md) for detailed migration instructions.
+
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/ethirajsrinivasan/rails-protip.
+Bug reports and pull requests are welcome on GitHub at https://github.com/ethirajsrinivasan/rails-protip. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](CODE_OF_CONDUCT.md) code of conduct.
 
+## Thanks
+
+Thanks to the [Protip](http://protip.rocks) project for the original jQuery tooltip plugin.
 
 ## License
 
 The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,8 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
-RSpec::Core::RakeTask.new
-task :default => :spec
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/UPGRADE_GUIDE.md
+++ b/UPGRADE_GUIDE.md
@@ -1,0 +1,171 @@
+# Upgrade Guide: Rails-Protip 0.x to 1.0
+
+## Overview
+
+Rails-Protip 1.0 modernizes the gem to work with current Ruby and Rails versions. This guide will help you upgrade smoothly.
+
+## What Changed
+
+### Version Requirements
+
+| Component | Old Version | New Version | Reason |
+|-----------|-------------|-------------|--------|
+| Ruby | >= 1.9.3 | >= 3.0 | Ruby 2.7 EOL (March 2023) |
+| Rails | (implicit) | >= 6.0 | Modern Rails support |
+
+### New Features
+
+- Support for Rails 6.x, 7.x, and 8.x
+- GitHub Actions CI workflow
+- Updated documentation for modern asset pipelines
+- Import Maps support documentation
+- Explicit railties dependency
+
+## Pre-Upgrade Checklist
+
+Before upgrading, ensure:
+
+- [ ] Your application runs Ruby 3.0 or higher
+- [ ] Your application runs Rails 6.0 or higher
+- [ ] You have a backup or version control
+- [ ] Your test suite passes
+
+## Upgrade Steps
+
+### 1. Update Your Gemfile
+
+```ruby
+# Old
+gem 'rails-protip'
+
+# New
+gem 'rails-protip', '~> 1.0'
+```
+
+### 2. Install the Updated Gem
+
+```bash
+bundle update rails-protip
+```
+
+### 3. Update Asset Configuration (if needed)
+
+#### For Sprockets (Rails 6.x / 7.x)
+
+No changes needed if you already have:
+
+```javascript
+//= require protip
+```
+
+And in your CSS manifest:
+
+```css
+*= require protip
+```
+
+#### For Import Maps (Rails 7+)
+
+Add to `config/importmap.rb`:
+
+```ruby
+pin "protip", to: "protip.js"
+```
+
+Import in your `application.js`:
+
+```javascript
+import "protip"
+```
+
+### 4. Verify jQuery is Loaded
+
+Rails-Protip requires jQuery. Ensure it's loaded before protip:
+
+**Sprockets:**
+```javascript
+//= require jquery
+//= require protip
+```
+
+**Import Maps:**
+```ruby
+# config/importmap.rb
+pin "jquery", to: "https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"
+pin "protip", to: "protip.js"
+```
+
+### 5. Test Your Tooltips
+
+1. Start your Rails server
+2. Navigate to pages with protip elements
+3. Verify tooltips appear and behave correctly
+4. Test custom configurations if you use protip.yml
+
+## Configuration
+
+Your existing `config/protip.yml` configuration file continues to work without changes:
+
+```yaml
+scheme: "orange"
+skin: "square"
+```
+
+## Troubleshooting
+
+### Tooltips Not Appearing
+
+**Issue**: Tooltips don't show up on elements.
+
+**Solutions**:
+1. Check browser console for JavaScript errors
+2. Verify jQuery is loaded before protip
+3. Ensure assets are properly included in your asset pipeline
+4. Confirm elements have the `protip` class and `data-pt-title` attribute
+
+### Asset Not Found
+
+**Issue**: `protip.js` not found error.
+
+**Solutions**:
+1. Run `bundle exec rails assets:precompile` in production
+2. Restart your Rails server in development
+3. Clear your browser cache
+4. Verify the gem is properly installed: `bundle list | grep rails-protip`
+
+### Import Maps Issues (Rails 7+)
+
+**Issue**: Module not found when using Import Maps.
+
+**Solutions**:
+1. Ensure you've added the pin to `config/importmap.rb`
+2. Run `bin/importmap pin protip`
+3. Check that jQuery is also pinned and imported first
+
+## Rolling Back
+
+If you need to roll back to the previous version:
+
+```ruby
+# Gemfile
+gem 'rails-protip', '~> 0.1.2'
+```
+
+Then run:
+```bash
+bundle update rails-protip
+```
+
+**Note**: Version 0.1.2 only supports older Ruby and Rails versions, which are no longer maintained.
+
+## Getting Help
+
+- **Issues**: [GitHub Issues](https://github.com/ethirajsrinivasan/rails-protip/issues)
+- **Security**: Email ethirajsrinivasan@gmail.com for security concerns
+
+## Additional Resources
+
+- [CHANGELOG.md](CHANGELOG.md) - Detailed list of changes
+- [README.md](README.md) - Full documentation
+- [Ruby Upgrade Guide](https://www.ruby-lang.org/en/downloads/)
+- [Rails Upgrade Guide](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html)

--- a/lib/rails/protip.rb
+++ b/lib/rails/protip.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/protip/version"
 
 module Rails

--- a/lib/rails/protip/version.rb
+++ b/lib/rails/protip/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module Rails
   module Protip
-    VERSION = "0.1.2"
+    VERSION = "1.0.0"
   end
 end

--- a/rails-protip.gemspec
+++ b/rails-protip.gemspec
@@ -1,7 +1,6 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'rails/protip/version'
+# frozen_string_literal: true
+
+require_relative "lib/rails/protip/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "rails-protip"
@@ -10,24 +9,35 @@ Gem::Specification.new do |spec|
   spec.email         = ["ethirajsrinivasan@gmail.com"]
 
   spec.summary       = "Tooltip gem based on jquery protip"
-  spec.description   = "Tooltip gem based on jquery protip"
+  spec.description   = "A Rails asset gem that integrates the jQuery Protip tooltip plugin for creating beautiful, customizable tooltips"
   spec.homepage      = "https://github.com/ethirajsrinivasan/rails-protip"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
-  # delete this section to allow pushing this gem to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "https://rubygems.org"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
+  spec.metadata = {
+    "allowed_push_host" => "https://rubygems.org",
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => "https://github.com/ethirajsrinivasan/rails-protip",
+    "bug_tracker_uri" => "https://github.com/ethirajsrinivasan/rails-protip/issues",
+    "changelog_uri" => "https://github.com/ethirajsrinivasan/rails-protip/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://github.com/ethirajsrinivasan/rails-protip/blob/master/README.md",
+    "rubygems_mfa_required" => "true"
+  }
+
+  spec.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.required_ruby_version = '>= 1.9.3'
-  spec.add_development_dependency "bundler", "~> 1.10"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency 'rspec'
+
+  spec.required_ruby_version = ">= 3.0"
+
+  spec.add_runtime_dependency "railties", ">= 6.0", "< 9.0"
+
+  spec.add_development_dependency "bundler", "~> 2.4"
+  spec.add_development_dependency "bundler-audit", "~> 0.9"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.12"
+  spec.add_development_dependency "rubocop", "~> 1.50"
 end

--- a/rails-protip.gemspec
+++ b/rails-protip.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "railties", ">= 6.0", "< 9.0"
 
-  spec.add_development_dependency "bundler", "~> 2.4"
   spec.add_development_dependency "bundler-audit", "~> 0.9"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.12"

--- a/spec/rails/protip/version_spec.rb
+++ b/spec/rails/protip/version_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+RSpec.describe Rails::Protip do
+  it "has a version number" do
+    expect(Rails::Protip::VERSION).not_to be_nil
+  end
+
+  it "defines a Rails engine" do
+    expect(Rails::Protip::Engine).to be < Rails::Engine
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "bundler/setup"
+require "logger"
 require "rails"
 require "rails/protip"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "rails"
+require "rails/protip"
+
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+end


### PR DESCRIPTION
## Summary
- Modernized for Ruby 3.0+ and Rails 6.0+
- Added CI, RuboCop, specs, and documentation
- Published to RubyGems and validated in the gems-demo Rails app

## Test plan
- [x] CI green on `modernize` branch
- [x] Validated in gems-demo with published gem versions

Made with [Cursor](https://cursor.com)